### PR TITLE
fixed warning when using gevent 1.0b2 

### DIFF
--- a/socketpool/backend_gevent.py
+++ b/socketpool/backend_gevent.py
@@ -7,7 +7,12 @@ import gevent
 from gevent import select
 from gevent import socket
 from gevent import queue
-from gevent import coros
+import warnings
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore",category=DeprecationWarning)
+    import gevent.coros
+
 
 from socketpool.pool import ConnectionPool
 


### PR DESCRIPTION
fixed a  warning when using gevent 1.0b2 version
