### PR TITLE
support passing backends as object

### DIFF
--- a/socketpool/pool.py
+++ b/socketpool/pool.py
@@ -48,8 +48,12 @@ class ConnectionPool(object):
                  max_size=10, options=None,
                  reap_connections=True, backend="thread"):
 
-        self.backend_mod = load_backend(backend)
-        self.backend = backend
+        if isinstance(backend, str):
+            self.backend_mod = load_backend(backend)
+            self.backend = backend
+        else:
+            self.backend_mod = backend
+            self.backend = str(getattr(backend, '__name__', backend))
         self.max_size = max_size
         self.pool = getattr(self.backend_mod, 'PriorityQueue')()
         self._free_conns = 0

--- a/tests/test_backend_finding.py
+++ b/tests/test_backend_finding.py
@@ -1,0 +1,31 @@
+import pytest
+from socketpool.pool import ConnectionPool
+from socketpool.conn import TcpConnector
+
+def make_and_check_backend(expected_name, **kw):
+    pool = ConnectionPool(TcpConnector, **kw)
+    assert pool.backend == expected_name
+    return pool
+
+
+def test_default_backend():
+    make_and_check_backend('thread')
+
+
+def test_thread_backend():
+    make_and_check_backend('thread', backend='thread')
+
+
+def test_gevent_backend():
+    pytest.importorskip('gevent')
+    make_and_check_backend('gevent', backend='gevent')
+
+
+def test_eventlet_backend():
+    pytest.importorskip('eventlet')
+    make_and_check_backend('eventlet', backend='eventlet')
+
+
+def test_thread_backend_as_module():
+    from socketpool import backend_thread
+    make_and_check_backend('socketpool.backend_thread', backend=backend_thread)


### PR DESCRIPTION
this change will allow to use https://bitbucket.org/RonnyPfannschmidt/socketpool_execnetbackend without hacking sys.modules
