### PR TITLE
Fix setup.py encoding issue.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ CLASSIFIERS = [
 
 
 # read long description
-with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as f:
-    long_description = f.read()
+with open(os.path.join(os.path.dirname(__file__), 'README.rst'), 'rb') as f:
+    long_description = f.read().decode('utf-8')
 
 DATA_FILES = [
         ('socketpool', ["LICENSE", "MANIFEST.in", "NOTICE", "README.rst",


### PR DESCRIPTION
README.rst is encoded as UTF-8 and is readable as-is on a system which
has UTF-8 as the default encoding.  However, on ascii-default systems we
get a traceback so we need to treat the content explicitly as bytes and
then explicitly decode them.